### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ fbpush requires or works with
     }
     ```   
   * Replace the **&lt;device_name&gt;** and the **&lt;user&gt;** in the above and the sample.conf is ready to test.    
-* Dry Run is currently compulsary (unless the --clowntown flag is set).
+* Dry Run is currently compulsory (unless the --clowntown flag is set).
     *   ``` $ fbpush -n sample.conf  ```
 * After dry run is succesful user should review the diff files. If the diff file looks correct conduct the actual push using
     *   ``` $ fbpush sample.conf ``` 


### PR DESCRIPTION
@facebook, I've corrected a typographical error in the documentation of the [fbpush](https://github.com/facebook/fbpush) project. Specifically, I've changed compulsary to compulsory. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
